### PR TITLE
Fix docker-compose that surfaces ports to internet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       # You will need a "postsrsd.secret" file in the "/etc/postsrsd/" directory
       - /etc/postsrsd:/config
     ports:
-      - 10001:10001
-      - 10002:10002
+      - 127.0.0.1:10001:10001
+      - 127.0.0.1:10002:10002
     restart: unless-stopped


### PR DESCRIPTION
Previously the docker-compose.yml file surfaced the postsrsd to not only postfix but also to the internet, bypassing the firewall.

This changes docker to surface the ports only to 127.0.0.1 to prevent them from being accessible via the internet.